### PR TITLE
Change OOP design & Display HoroscopeResponse as an API

### DIFF
--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -14,7 +14,7 @@ function App() {
       horoscope_sign: horoscopeSign,
     };
     axios
-      .post("/user", JSON.stringify(request), {
+      .post("/user-details", JSON.stringify(request), {
         headers: {
           "Content-Type": "application/json",
         },
@@ -33,7 +33,7 @@ function App() {
       <h2 style={{ marginTop: "1em", marginBottom: "20px" }}>Horoscope</h2>
       <Alert variant="primary" className="col-md-6">
         {/* prettier-ignore */}
-        <p>This App Provides horoscope info for sun signs such as Lucky Number, Lucky Color, 
+        <p>This App Provides horoscope info for sun signs such as Lucky Number, Lucky Color,
                     Mood, Color, Compatibility with other sun signs, description of a sign for that day, etc.</p>
         <hr />
         <p>

--- a/server/generated-js/rpc-request.js
+++ b/server/generated-js/rpc-request.js
@@ -1,26 +1,41 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.GrpcRequest = void 0;
+exports.getHoroscopeDetailsForUser = exports.horoscopeUserDetails = void 0;
 const grpc_js_1 = require("@grpc/grpc-js");
 const horoscope_grpc_pb_1 = require("../generated-proto/services/horoscope/v1/horoscope_grpc_pb");
 const horoscope_pb_1 = require("../generated-proto/services/horoscope/v1/horoscope_pb");
 class GrpcRequest {
-    GetGrpcRequest(name, horoscopeSign) {
-        // Create a stub
-        const client = new horoscope_grpc_pb_1.HoroscopeServiceClient("localhost:50051", grpc_js_1.credentials.createInsecure());
+    /**
+     * Sends the HoroscopeRequest to GRPC endpoint
+     * @param request the callback request
+     */
+    static sendRequest(request) {
         // Implement the HoroscopeRequest that will be sent through the rpc
-        const request = new horoscope_pb_1.HoroscopeRequest();
-        request.setName(name);
-        request.setHoroscopeSign(horoscopeSign);
-        // Make rpc request and receive the response as a callback
-        client.getHoroscopeInfo(request, (err, response) => {
-            if (err) {
-                console.log(err);
+        const horoscopeRequest = new horoscope_pb_1.HoroscopeRequest();
+        horoscopeRequest.setName(request.body.name);
+        horoscopeRequest.setHoroscopeSign(request.body.horoscope_sign);
+        // Make rpc horoscopeRequest and receive the response as a callback
+        GrpcRequest.client.getHoroscopeInfo(horoscopeRequest, (error, horoscopeResponse) => {
+            if (error) {
+                console.log(error);
                 return;
             }
-            const responseObj = response.toObject();
-            console.log(responseObj);
+            this.horoscopeResponse = horoscopeResponse;
         });
     }
+    // Method to return the GRPC Horoscope response
+    static getHoroscopeResponse() {
+        console.log(this.horoscopeResponse.toObject());
+        return this.horoscopeResponse.toObject();
+    }
 }
-exports.GrpcRequest = GrpcRequest;
+GrpcRequest.client = new horoscope_grpc_pb_1.HoroscopeServiceClient("localhost:50051", grpc_js_1.credentials.createInsecure());
+const horoscopeUserDetails = (request, response) => {
+    GrpcRequest.sendRequest(request);
+    response.status(200).end();
+};
+exports.horoscopeUserDetails = horoscopeUserDetails;
+const getHoroscopeDetailsForUser = (req, res) => {
+    res.status(200).send(GrpcRequest.getHoroscopeResponse());
+};
+exports.getHoroscopeDetailsForUser = getHoroscopeDetailsForUser;

--- a/server/generated-js/server.js
+++ b/server/generated-js/server.js
@@ -1,18 +1,41 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = __importDefault(require("express"));
-const rpc_request_1 = require("./rpc-request");
+const grpcRequest = __importStar(require("./rpc-request"));
 // Port number
 const PORT = 7777;
 const app = (0, express_1.default)();
 app.use(express_1.default.json());
-app.post("/user", (req, res) => {
-    const grpc_request = new rpc_request_1.GrpcRequest();
-    grpc_request.GetGrpcRequest(req.body["name"], req.body["horoscope_sign"]);
-});
+app.post("/user-details", grpcRequest.horoscopeUserDetails);
+app.get("/horoscope-details", grpcRequest.getHoroscopeDetailsForUser);
+// console.log(grpcRequest.getHoroscopeDetailsForUser);
 app.listen(PORT, () => {
     console.log(`Now listening on port ${PORT}`);
 });
+exports.default = app;

--- a/server/generated-proto/services/horoscope/v1/horoscope_grpc_pb.d.ts
+++ b/server/generated-proto/services/horoscope/v1/horoscope_grpc_pb.d.ts
@@ -7,35 +7,93 @@
 import * as grpc from "@grpc/grpc-js";
 import * as services_horoscope_v1_horoscope_pb from "../../../services/horoscope/v1/horoscope_pb";
 
-interface IHoroscopeServiceService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
-    getHoroscopeInfo: IHoroscopeServiceService_IGetHoroscopeInfo;
+interface IHoroscopeServiceService
+  extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
+  getHoroscopeInfo: IHoroscopeServiceService_IGetHoroscopeInfo;
 }
 
-interface IHoroscopeServiceService_IGetHoroscopeInfo extends grpc.MethodDefinition<services_horoscope_v1_horoscope_pb.HoroscopeRequest, services_horoscope_v1_horoscope_pb.HoroscopeResponse> {
-    path: "/services.horoscope.v1.HoroscopeService/GetHoroscopeInfo";
-    requestStream: false;
-    responseStream: false;
-    requestSerialize: grpc.serialize<services_horoscope_v1_horoscope_pb.HoroscopeRequest>;
-    requestDeserialize: grpc.deserialize<services_horoscope_v1_horoscope_pb.HoroscopeRequest>;
-    responseSerialize: grpc.serialize<services_horoscope_v1_horoscope_pb.HoroscopeResponse>;
-    responseDeserialize: grpc.deserialize<services_horoscope_v1_horoscope_pb.HoroscopeResponse>;
+interface IHoroscopeServiceService_IGetHoroscopeInfo
+  extends grpc.MethodDefinition<
+    services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    services_horoscope_v1_horoscope_pb.HoroscopeResponse
+  > {
+  path: "/services.horoscope.v1.HoroscopeService/GetHoroscopeInfo";
+  requestStream: false;
+  responseStream: false;
+  requestSerialize: grpc.serialize<services_horoscope_v1_horoscope_pb.HoroscopeRequest>;
+  requestDeserialize: grpc.deserialize<services_horoscope_v1_horoscope_pb.HoroscopeRequest>;
+  responseSerialize: grpc.serialize<services_horoscope_v1_horoscope_pb.HoroscopeResponse>;
+  responseDeserialize: grpc.deserialize<services_horoscope_v1_horoscope_pb.HoroscopeResponse>;
 }
 
 export const HoroscopeServiceService: IHoroscopeServiceService;
 
-export interface IHoroscopeServiceServer extends grpc.UntypedServiceImplementation {
-    getHoroscopeInfo: grpc.handleUnaryCall<services_horoscope_v1_horoscope_pb.HoroscopeRequest, services_horoscope_v1_horoscope_pb.HoroscopeResponse>;
+export interface IHoroscopeServiceServer
+  extends grpc.UntypedServiceImplementation {
+  getHoroscopeInfo: grpc.handleUnaryCall<
+    services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    services_horoscope_v1_horoscope_pb.HoroscopeResponse
+  >;
 }
 
 export interface IHoroscopeServiceClient {
-    getHoroscopeInfo(request: services_horoscope_v1_horoscope_pb.HoroscopeRequest, callback: (error: grpc.ServiceError | null, response: services_horoscope_v1_horoscope_pb.HoroscopeResponse) => void): grpc.ClientUnaryCall;
-    getHoroscopeInfo(request: services_horoscope_v1_horoscope_pb.HoroscopeRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: services_horoscope_v1_horoscope_pb.HoroscopeResponse) => void): grpc.ClientUnaryCall;
-    getHoroscopeInfo(request: services_horoscope_v1_horoscope_pb.HoroscopeRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: services_horoscope_v1_horoscope_pb.HoroscopeResponse) => void): grpc.ClientUnaryCall;
+  getHoroscopeInfo(
+    request: services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    callback: (
+      error: grpc.ServiceError | null,
+      response: services_horoscope_v1_horoscope_pb.HoroscopeResponse
+    ) => void
+  ): grpc.ClientUnaryCall;
+  getHoroscopeInfo(
+    request: services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      error: grpc.ServiceError | null,
+      response: services_horoscope_v1_horoscope_pb.HoroscopeResponse
+    ) => void
+  ): grpc.ClientUnaryCall;
+  getHoroscopeInfo(
+    request: services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    metadata: grpc.Metadata,
+    options: Partial<grpc.CallOptions>,
+    callback: (
+      error: grpc.ServiceError | null,
+      response: services_horoscope_v1_horoscope_pb.HoroscopeResponse
+    ) => void
+  ): grpc.ClientUnaryCall;
 }
 
-export class HoroscopeServiceClient extends grpc.Client implements IHoroscopeServiceClient {
-    constructor(address: string, credentials: grpc.ChannelCredentials, options?: Partial<grpc.ClientOptions>);
-    public getHoroscopeInfo(request: services_horoscope_v1_horoscope_pb.HoroscopeRequest, callback: (error: grpc.ServiceError | null, response: services_horoscope_v1_horoscope_pb.HoroscopeResponse) => void): grpc.ClientUnaryCall;
-    public getHoroscopeInfo(request: services_horoscope_v1_horoscope_pb.HoroscopeRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: services_horoscope_v1_horoscope_pb.HoroscopeResponse) => void): grpc.ClientUnaryCall;
-    public getHoroscopeInfo(request: services_horoscope_v1_horoscope_pb.HoroscopeRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: services_horoscope_v1_horoscope_pb.HoroscopeResponse) => void): grpc.ClientUnaryCall;
+export class HoroscopeServiceClient
+  extends grpc.Client
+  implements IHoroscopeServiceClient
+{
+  constructor(
+    address: string,
+    credentials: grpc.ChannelCredentials,
+    options?: Partial<grpc.ClientOptions>
+  );
+  public getHoroscopeInfo(
+    request: services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    callback: (
+      error: grpc.ServiceError | null,
+      response: services_horoscope_v1_horoscope_pb.HoroscopeResponse
+    ) => void
+  ): grpc.ClientUnaryCall;
+  public getHoroscopeInfo(
+    request: services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    metadata: grpc.Metadata,
+    callback: (
+      error: grpc.ServiceError | null,
+      response: services_horoscope_v1_horoscope_pb.HoroscopeResponse
+    ) => void
+  ): grpc.ClientUnaryCall;
+  public getHoroscopeInfo(
+    request: services_horoscope_v1_horoscope_pb.HoroscopeRequest,
+    metadata: grpc.Metadata,
+    options: Partial<grpc.CallOptions>,
+    callback: (
+      error: grpc.ServiceError | null,
+      response: services_horoscope_v1_horoscope_pb.HoroscopeResponse
+    ) => void
+  ): grpc.ClientUnaryCall;
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,5 @@
 import express, { Express, Request, Response } from "express";
-import { GrpcRequest } from './rpc-request';
+import * as grpcRequest from "./rpc-request";
 
 // Port number
 const PORT = 7777;
@@ -7,12 +7,13 @@ const app: Express = express();
 
 app.use(express.json());
 
-app.post("/user", (req: Request, res: Response) => {
-  const grpc_request = new GrpcRequest();
-  grpc_request.GetGrpcRequest(req.body["name"], req.body["horoscope_sign"])
-  
-});
+app.post("/user-details", grpcRequest.horoscopeUserDetails);
+app.get("/horoscope-details", grpcRequest.getHoroscopeDetailsForUser);
+
+// console.log(grpcRequest.getHoroscopeDetailsForUser);
 
 app.listen(PORT, () => {
   console.log(`Now listening on port ${PORT}`);
 });
+
+export default app;


### PR DESCRIPTION
**Implementation**

- Changed the OOP styling to make it more readable and scalable. 
- Created callback functions: 
     - One that handles the POST request and performs the GRPC call 
     - Another that handles the GET request and shows the Horoscope Response from the GRPC to the client as an API

**Test**
- Checked the console for any errors and nothing was there. 
- Screenshot of the API showing in the browser is below: 


<img width="1439" alt="Screen Shot 2022-12-11 at 2 18 21 PM" src="https://user-images.githubusercontent.com/32971892/206926737-9b4d01e3-0866-4eae-ab6d-46dc3ce68121.png">
